### PR TITLE
only handle alerts if document not hidden, make polling interval configurable

### DIFF
--- a/jupyter_jupyterlab_wall_config.py
+++ b/jupyter_jupyterlab_wall_config.py
@@ -15,3 +15,5 @@ c.AlertsConfig.alerts = {
         "priority": 3
     }
 }
+
+c.AlertsConfig.poll_interval = 60  # seconds

--- a/jupyterlab_wall/__init__.py
+++ b/jupyterlab_wall/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from jupyter_core.application import PageConfig
 
 try:
     from ._version import __version__
@@ -40,6 +41,7 @@ def _load_jupyter_server_extension(server_app):
         config = AlertsConfig(parent=server_app)
         data = config.get_alerts_config()
         server_app.web_app.settings.update({'alerts': data})
+        PageConfig.setOption("pollInterval", str(config.poll_interval * 1000))
         setup_handlers(server_app.web_app, logger)
         name = "jupyterlab_wall"
         server_app.log.info(f"Registered {name} server extension")

--- a/jupyterlab_wall/config.py
+++ b/jupyterlab_wall/config.py
@@ -6,6 +6,11 @@ class AlertsConfig(Configurable):
         key_trait = Unicode(),
         per_key_traits = {"message": Unicode(), "watch_file": Unicode(), "priority": Integer()}).tag(config=True)
 
+    poll_interval = Integer(
+        60,
+        help="Interval in seconds between alert polls"
+    ).tag(config=True)
+
     def get_alerts_config(self):
         out = {k: self.alerts[k] for k in self.alerts}
         return out

--- a/src/alertManager.ts
+++ b/src/alertManager.ts
@@ -62,8 +62,11 @@ export class AlertManager extends Object {
   }
 
   async watchAlertStatus(): Promise<void> {
-    this._handleIncomingAlerts();
-    setInterval(this._handleIncomingAlerts, this.pollInterval);
+    setInterval(() => {
+      if (document.visibilityState !== 'hidden') {
+        this._handleIncomingAlerts();
+      }
+    }, this.pollInterval);
   }
 
   public get alertAddedSignal(): ISignal<this, AlertMessage> {

--- a/src/alertManager.ts
+++ b/src/alertManager.ts
@@ -2,6 +2,7 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { JupyterFrontEnd, LabShell } from '@jupyterlab/application';
 import { IStateDB } from '@jupyterlab/statedb';
 import { MainAreaWidget, Notification } from '@jupyterlab/apputils';
+import { PageConfig } from '@jupyterlab/coreutils';
 import { AlertMessage } from './alertMessage';
 import { AlertHeader } from './alertHeader';
 import { requestAPI } from './handler';
@@ -45,7 +46,8 @@ export class AlertManager extends Object {
     this.app = app;
     this.state = state;
     this.stateMutex = new Mutex();
-    this.pollInterval = 5000 + Math.floor(Math.random() * 1001);
+    const configuredInterval = parseInt(PageConfig.getOption('pollInterval') || '60000', 10);
+    this.pollInterval = configuredInterval + Math.floor(Math.random() * (configuredInterval * 0.1));
 
     this.app.commands.commandExecuted.connect(async (_, args) => {
       // make sure new tabs opened after alerts have started will get a header

--- a/tests/alertManager.spec.ts
+++ b/tests/alertManager.spec.ts
@@ -1,12 +1,19 @@
 import { AlertManager, ACTIVE_ALERTS } from '../src/alertManager';
 import { AlertMessage } from '../src/alertMessage';
 import { JupyterFrontEnd } from '@jupyterlab/application';
+import { PageConfig } from '@jupyterlab/coreutils';
 import { IStateDB } from '@jupyterlab/statedb';
 import { Signal } from '@lumino/signaling';
 
 // Mock requestAPI
 jest.mock('../src/handler', () => ({
   requestAPI: jest.fn()
+}));
+
+jest.mock('@jupyterlab/coreutils', () => ({
+  PageConfig: {
+    getOption: jest.fn()
+  }
 }));
 
 import { requestAPI } from '../src/handler';
@@ -17,6 +24,8 @@ describe('AlertManager', () => {
   let manager: AlertManager;
 
   beforeEach(() => {
+    (PageConfig.getOption as jest.Mock).mockReturnValue('');
+
     app = {
       commands: {
         commandExecuted: new Signal<any, any>({} as any)
@@ -36,10 +45,20 @@ describe('AlertManager', () => {
     manager = new AlertManager(app, state);
   });
 
-  it('should initialize correctly', () => {
-    expect(manager).toBeDefined();
-    expect(manager.getPollInterval()).toBeGreaterThanOrEqual(5000);
-    expect(manager.getPollInterval()).toBeLessThanOrEqual(6000);
+  describe('poll interval configuration', () => {
+    it('should use default poll interval when not set', () => {
+      (PageConfig.getOption as jest.Mock).mockReturnValue('');
+      const defaultManager = new AlertManager(app, state);
+      expect(defaultManager.getPollInterval()).toBeGreaterThanOrEqual(60000);
+      expect(defaultManager.getPollInterval()).toBeLessThanOrEqual(66000);
+    });
+
+    it('should use configured poll interval when set', () => {
+      (PageConfig.getOption as jest.Mock).mockReturnValue('30000');
+      const configuredManager = new AlertManager(app, state);
+      expect(configuredManager.getPollInterval()).toBeGreaterThanOrEqual(30000);
+      expect(configuredManager.getPollInterval()).toBeLessThanOrEqual(33000);
+    });
   });
 
   describe('_getServiceAlerts', () => {


### PR DESCRIPTION
two changes here, both to drive a little less traffic.

- added a change to call `_handleIncomingAlerts();` only if the document is not hidden
  - no use in checking for and posting a banner not visible to the user
  - additionally does not update the server's last activity time
- made the poll interval configurable with a default value of 60s
  - extensible for other sites' use cases (whatever those might be)
  - added a test to check this and updated the default test case